### PR TITLE
Update Liberty and MicroProfile versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>net.wasdev.wlp.maven.parent</groupId>
+        <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-app-parent</artifactId>
-        <version>2.7</version>
+        <version>3.3.4</version>
         <relativePath/>
     </parent>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.0</version>
+            <version>4.0.1</version>
             <scope>provided</scope>
             <type>pom</type>
         </dependency>
@@ -162,16 +162,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
-                    <assemblyArtifact>
-                        <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-runtime</artifactId>
-                        <version>20.0.0.4</version>
-                        <type>zip</type>
-                    </assemblyArtifact>
                     <configFile>src/main/liberty/config/server.xml</configFile>
                     <include>${packaging.type}</include>
                     <bootstrapProperties>

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -1,7 +1,7 @@
 <server description="Sample Liberty server">
 
     <featureManager>
-        <feature>microProfile-3.0</feature>
+        <feature>microProfile-4.0</feature>
         <feature>jpa-2.2</feature>
     </featureManager>
 


### PR DESCRIPTION
Updates:
* Liberty to use [the latest openliberty-kernal version](https://github.com/OpenLiberty/ci.maven#liberty-installation-configuration) by not defining an `<assemblyArtifact>` in the `liberty-maven-plugin`
* liberty-maven-app-parent to 3.3.4. This updates the `liberty-maven-plugin` to 3.3.4 and hence enables `liberty:dev` mode
* MicroProfile to 4.0

Resolves part 1 of #1 